### PR TITLE
Manifest: update to 4.1.0

### DIFF
--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -1,29 +1,29 @@
 {
-    "app-id": "com.github.cassidyjames.dippi",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version": "45",
-    "sdk": "org.gnome.Sdk",
-    "command": "com.github.cassidyjames.dippi",
-    "finish-args": [
-        "--share=ipc",
-        "--socket=fallback-x11",
-        "--socket=wayland",
-        "--device=dri",
-        "--share=ipc"
-    ],
-    "modules": [{
-        "name": "dippi",
-        "buildsystem": "meson",
-        "config-opts": ["--buildtype=release"],
-        "sources": [{
-            "type": "git",
-            "url": "https://github.com/cassidyjames/dippi.git",
-            "tag": "4.0.6",
-            "commit": "1f5c8a7c80b0a81fc9e9313496dd72530a599dda",
-            "x-checker-data": {
-                "type": "git",
-                "tag-pattern": "^([\\d.]+)$"
-            }
-        }]
+  "app-id": "com.github.cassidyjames.dippi",
+  "runtime" : "org.gnome.Platform",
+  "runtime-version": "46",
+  "sdk": "org.gnome.Sdk",
+  "command": "com.github.cassidyjames.dippi",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--share=ipc"
+  ],
+  "modules": [{
+    "name": "dippi",
+    "buildsystem": "meson",
+    "config-opts": ["--buildtype=release"],
+    "sources": [{
+      "type": "git",
+      "url": "https://github.com/cassidyjames/dippi.git",
+      "tag": "4.1.0",
+      "commit": "f83f342b753dc854dcbbf5d0522924273b3c388d",
+      "x-checker-data": {
+        "type": "git",
+        "tag-pattern": "^([\\d.]+)$"
+      }
     }]
+  }]
 }


### PR DESCRIPTION
- Update to 4.1.0 release
- Bump to GNOME 46 runtime