### PR TITLE
Update Runtime to GNOME 48

### DIFF
--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.cassidyjames.dippi",
   "runtime" : "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "com.github.cassidyjames.dippi",
   "finish-args": [


### PR DESCRIPTION
Update to LibAdw 1.7 changes dark theme colors and corner rounding radius. Runtime for GNOME 46 now eol, and GNOME Software now says the app is "no longer receiving updates" until the runtime is updated. I noticed no new issues on my machine (Fedora 42).